### PR TITLE
doc: use banner image from media repository

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-![amok](https://cloud.githubusercontent.com/assets/157787/9637439/58c03000-51d3-11e5-8502-0b7d57096d57.png)
+![Amok.js](https://cdn.rawgit.com/amokjs/media/master/banner.svg)
 
 Amok is a free open source, editor agnostic, cross-platform command line
 tool for a hassle-free live development, testing and debugging workflow for web browsers.


### PR DESCRIPTION
We are hard-linking to a png version of the old logo with GitHub's
files, which is tedious to update as we iterate on the branding.

This changes the image url to point to the svg from the repository
through rawgit in order to get a correct mime-type. This will make
iterating on said image easier across the different repositories.