### PR TITLE
[WIP] CSS hotpatching support

### DIFF
--- a/bin/amok
+++ b/bin/amok
@@ -66,6 +66,7 @@ if (program.watch) {
 
 if (program.hot) {
   amok.use(amok.hotpatch());
+  amok.use(amok.hotpatch_css());
 }
 
 if (program.browser) {

--- a/lib/hotpatch-css.js
+++ b/lib/hotpatch-css.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+const util = require('util');
+
+const debug = util.debuglog('amok-hotpatch-css');
+
+function hotpatch() {
+  return function hotpatch(client, runner, done) {
+    let cwd = runner.get('cwd');
+    if (cwd) {
+      cwd = path.resolve(cwd);
+    } else {
+      cwd = process.cwd();
+    }
+
+    let stylesheets = {};
+    let watchers = {};
+
+    let clearWatchers = () => {
+      debug('clear');
+      stylesheets = {};
+
+      Object.keys(watchers).forEach(key => {
+        watchers[key].close();
+      });
+
+      watchers = {};
+    };
+
+    let onStyleSheetAdd = stylesheet => {
+      debug('parse %s', util.inspect(stylesheet));
+
+      if (stylesheet.origin !== 'regular') {
+        debug("Ignoring css of origin %s", stylesheet.origin);
+        return;
+      }
+
+      // TODO: inline stylesheet support
+      if (stylesheet.isInline) {
+        debug("Ignoring inline css");
+        return;
+      }
+
+      let uri = url.parse(stylesheet.sourceURL);
+      let pageUri = url.parse(runner.get('url') || '');
+      let filename = null;
+      // let sources = runner.get('stylesheets') || {};
+
+      if (uri.protocol === 'file:') {
+        filename = path.normalize(uri.pathname);
+        if (filename.match(/^\\[a-zA-Z]:\\/)) {
+          filename = filename.slice(1);
+        }
+      } else if (uri.protocol === 'http:') {
+        filename = uri.pathname.slice(1);
+        // if (sources[path.normalize(filename)]) {
+        //   filename = path.resolve(sources[path.normalize(filename)]);
+        // } else
+        if (uri.host === pageUri.host) {
+          filename = path.resolve(cwd, filename);
+        } else {
+          filename = null;
+        }
+      }
+
+      if (!filename) {
+        return;
+      }
+
+      stylesheets[filename] = stylesheet;
+
+      let dirname = path.dirname(filename);
+      if (watchers[dirname]) {
+        return;
+      }
+
+      debug('watch directory %s', dirname);
+      let watcher = fs.watch(dirname);
+      watchers[dirname] = watcher;
+
+      let streams = {};
+      watcher.on('change', (event, filename) => {
+        if (!filename) {
+          return;
+        }
+
+        filename = path.resolve(dirname, filename);
+
+        let stylesheet = stylesheets[filename];
+        if (!stylesheet) {
+          return;
+        }
+
+        debug(event, filename);
+        if (streams[filename]) {
+          return;
+        }
+
+        let source = '';
+        let stream = fs.createReadStream(filename);
+        streams[filename] = stream;
+
+        stream.setEncoding('utf-8');
+        stream.on('data', chunk => {
+          source += chunk;
+        });
+
+        stream.on('end', () => {
+          streams[filename] = null;
+
+          if (source.length === 0) {
+            return;
+          }
+
+          debug('patch stylesheet %s (%d bytes) ', stylesheet.sourceURL, source.length);
+          client.request("CSS.setStyleSheetText", {
+            styleSheetId: stylesheet.styleSheetId,
+            text: source
+          }, (error, result) => {
+            if (error) {
+              debug('set css text error %s', util.inspect(error));
+              return client.emit('error', error);
+            }
+
+            let payload = JSON.stringify({
+              detail: {
+                filename: path.relative(cwd, filename),
+              }
+            });
+
+            let cmd = [
+              'var event = new CustomEvent(\'stylesheetChange\',' + payload + ');',
+              'window.dispatchEvent(event);',
+            ].join('\n');
+
+            debug('evaluate patch event');
+            client.runtime.evaluate(cmd, error => {
+              if (error) {
+                debug('evaluate error %s', util.inspect(error));
+                return client.emit('error', error);
+              }
+            });
+          });
+        });
+      });
+    };
+
+    client.on('message', (method, params) => {
+      if (method === 'CSS.styleSheetAdded') {
+        onStyleSheetAdd(params.header);
+      } else if (method === 'DOM.documentUpdated') {
+        clearWatchers();
+      }
+      // else if (method === 'CSS.styleSheetRemoved') {
+      //
+      // } else if (method === 'CSS.styleSheetChanged') {
+      //
+      // }
+    });
+
+    client.on('close', () => {
+      debug('close');
+      stylesheets = {};
+
+      Object.keys(watchers).forEach(key => {
+        watchers[key].close();
+      });
+
+      watchers = {};
+    });
+
+    client.on('connect', () => {
+      // CSS domain requires DOM
+      client.request('DOM.enable', error => {
+        if (error) {
+          return client.emit('error', error);
+        }
+
+        client.request('CSS.enable', error => {
+          if (error) {
+            return client.emit('error', error);
+          }
+        });
+      });
+    });
+
+    done();
+  };
+}
+
+module.exports = hotpatch;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ module.exports = require('./runner');
 module.exports.browse = require('./browse');
 module.exports.compile = require('./compile');
 module.exports.hotpatch = require('./hotpatch');
+module.exports.hotpatch_css = require('./hotpatch-css');
 module.exports.inspect = require('./inspect');
 module.exports.multiplex = require('./multiplex');
 module.exports.interact = require('./interact');


### PR DESCRIPTION
This patch provides support for css hotpatching. Right now, it's more of a proof-of-concept, and I intend to polish it over a few iterations to get it to a more mature state suitable of being merged.

At this moment, the code is pretty much a copy of the js patching code with a few changes made to patch css instead. This results in a lot of duplication. I think it would generally be a good idea to move the common code (e.g. finding the source file on disk, creating a file read stream) into some helper module, so that not only js/css but document/image in the future can take advantage of it.

What's in:
- Preliminary css hotpatching support. To try it, clone the repo, head to `examples/mithril`, and run `npm start`. As you edit `stylesheet/app.css`, the changes should be reflected in browser.

What's missing:
- Test suite.
- Proper CLI option. Right now it just piggybacks on `--hot`

Questions:
- Should css patching get its own CLI option? I think @caspervonb you mentioned that you considered stylesheets and images just another part of document patching, so should all of the three together get one CLI flag instead?
